### PR TITLE
Adds possibility to skip SPF record type check.

### DIFF
--- a/lib/spf/query/query.rb
+++ b/lib/spf/query/query.rb
@@ -12,18 +12,20 @@ module SPF
     # @param [Resolv::DNS] resolver
     #   The optional resolver to use.
     #
+    # @param [Boolean]
+    #   Skip SPF record (discontined at RFC 7208)
+    #
     # @return [String, nil]
     #   The SPF record or `nil` if there is none.
     #
     # @api semipublic
     #
-    def self.query(domain,resolver=Resolv::DNS.new)
-      # check for an SPF record on the domain
-      begin
-        record = resolver.getresource(domain, Resolv::DNS::Resource::IN::SPF)
+    def self.query(domain,resolver=Resolv::DNS.new, skip_spf_record_type=false)
 
-        return record.strings.join(' ')
-      rescue Resolv::ResolvError
+      unless skip_spf_record_type
+        # check for an SPF record on the domain
+        spf_record = check_for_spf_record(domain, resolver)
+        return spf_record unless spf_record.nil?
       end
 
       # check for SPF in the TXT records
@@ -43,6 +45,29 @@ module SPF
       end
 
       return nil
+    end
+
+    #
+    # Queries the domain for it's SPF type record.
+    #
+    # @param [String] domain
+    #   The domain to query.
+    #
+    # @param [Resolv::DNS] resolver
+    #   The optional resolver to use.
+    #
+    # @return [String, nil]
+    #   The SPF record or `nil` if there is none.
+    #
+    # @api semipublic
+    #
+    def self.check_for_spf_record(domain, resolver=Resolv::DNS.new)
+      begin
+        record = resolver.getresource(domain, Resolv::DNS::Resource::IN::SPF)
+
+        return record.strings.join(' ')
+      rescue Resolv::ResolvError
+      end
     end
   end
 end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'spf/query/query'
-
 describe SPF::Query do
   subject { described_class }
 
@@ -32,6 +31,15 @@ describe SPF::Query do
 
       it "should return nil" do
         expect(subject.query(domain)).to be_nil
+      end
+    end
+
+    context 'when skip spf record type check' do
+      let(:domain) { 'getlua.com' }
+
+      it "skip properly" do
+        expect_any_instance_of(Resolv::DNS).not_to receive(:get_resource).with(domain, Resolv::DNS::Resource::IN::SPF)
+        subject.query(domain)
       end
     end
   end


### PR DESCRIPTION
fixes #3 

Adding possibility to skip SPF type check.

SPF record type was discontinued at [RFC 7208](https://tools.ietf.org/html/rfc7208#section-3.1).
