### PR TITLE
Fix bug in Mechanism#to_s with neutral qualifier.

### DIFF
--- a/lib/spf/query/mechanism.rb
+++ b/lib/spf/query/mechanism.rb
@@ -6,7 +6,7 @@ module SPF
         '+' => :pass,
         '-' => :fail,
         '~' => :soft_fail,
-        '?' => :neuatral
+        '?' => :neutral
       }
 
       attr_reader :name


### PR DESCRIPTION
#to_s wouldn't generate a neutral qualifier successfully due to a typo in the QUALIFIERS definition.