### PR TITLE
Allow the use of bundler 2.x for running the tests

### DIFF
--- a/spf-query.gemspec
+++ b/spf-query.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "parslet", "~> 1.0"
 
-  gem.add_development_dependency "bundler", "~> 1.6"
+  gem.add_development_dependency "bundler", ">= 1.6"
   gem.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This allows the tests to pass on Travis CI for Ruby versions using Bundler 2.0.1 already.

This should allow all currently failing tests in #11 to pass on Travis CI.