### PR TITLE
Parser should allow %{v} macro_string

### DIFF
--- a/lib/spf/query/parser.rb
+++ b/lib/spf/query/parser.rb
@@ -151,7 +151,7 @@ module SPF
         ).as(:macro)
       end
       rule(:macro_literal) { match['\x21-\x24'] | match['\x26-\x7e'] }
-      rule(:macro_letter) { match['slodiphcrt'] }
+      rule(:macro_letter) { match['slodiphcrtv'] }
       rule(:transformers) do
         digit.repeat(1).as(:digits).maybe >> str('r').as(:reverse).maybe
       end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -427,6 +427,17 @@ describe Parser do
           {macro: {letter: 'd'}}
         ]}
       end
+
+      it "should parse a macro_string with the v macro_letter" do
+        expect(subject.parse('%{ir}.%{v}.%{d}.foo.bar')).to be == {macro_string: [
+          {macro: {letter: 'i', reverse: 'r'}},
+          {literal: '.'},
+          {macro: {letter: 'v'}},
+          {literal: '.'},
+          {macro: {letter: 'd'}},
+          {literal: '.foo.bar'}
+        ]}
+      end
     end
 
     describe "macro_string?" do


### PR DESCRIPTION
Hi! Thank you for this gem.

I noticed the gem is failing to parse the following SPF Record: `v=spf1 include:%{ir}.%{v}.%{d}.spf.has.pphosted.com -all`:

```
DEVELOPMENT irb(main):001> SPF::Query::Parser.parse("v=spf1 include:%{ir}.%{v}.%{d}.spf.has.pphosted.com -all")
/Users/rafael/.asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/parslet-1.8.2/lib/parslet/cause.rb:70:in `raise': Failed to match sequence (VERSION SP{1, } rules:TERMS SP{0, }) at line 1 char 22. (Parslet::ParseFailed)
```

This is because the parser is not expecting the `%{v}` macro, which is valid according to the documentation: https://datatracker.ietf.org/doc/html/rfc7208#section-7.4.

Thus, this PR adds the missing `v` as a valid `macro_letter`.